### PR TITLE
Feature/allow sdcards

### DIFF
--- a/arch4bone.sh
+++ b/arch4bone.sh
@@ -228,8 +228,8 @@ if [[ ${device} == /dev/mmcblk* ]]; then
    part1="${device}p1"
    part2="${device}p2"
 else 
-   part1="${device}p1"
-   part2="${device}p2"
+   part1="${device}1"
+   part2="${device}2"
 fi
 
 # Create a temporary directory within /tmp.


### PR DESCRIPTION
Sdcards in some readers show up as /dev/mmcblkXpY, much like they do on the beaglebone. These commits allow the script to work with sdcards when you do not use the mmc option.
