### PR TITLE
Changed --"tar -xf /tmp/bone/ArchLinuxARM-am33x-latest.tar.gz -C /tmp/bo...

### DIFF
--- a/arch4bone.sh
+++ b/arch4bone.sh
@@ -301,7 +301,7 @@ mkdir -p /tmp/bone/root
 mount $part2 /tmp/bone/root
 
 # ... extract the root filesystem tarball here ...
-tar -xf /tmp/bone/ArchLinuxARM-am33x-latest.tar.gz -C /tmp/bone/root
+bsdtar -xpf /tmp/bone/ArchLinuxARM-am33x-latest.tar.gz -C /tmp/bone/root
 
 # ... and unmount the partition.
 umount /tmp/bone/root


### PR DESCRIPTION
...ne/root"

too --
"bsdtar -xpf /tmp/bone/ArchLinuxARM-am33x-latest.tar.gz -C /tmp/bone/root"

Should throw less "unknown header keyword" errors
